### PR TITLE
Support sync subscription flow

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -77,6 +77,40 @@ module Api
         end
       end
 
+      def create_sync
+        result = ::Events::CreateSyncService.call(
+          organization: current_organization,
+          params: create_params,
+          timestamp: Time.current.to_f,
+          metadata: event_metadata,
+        )
+
+        if result.success?
+          event_json_str = ::V1::EventSerializer.new(
+            result.event,
+            root_name: "event",
+          ).to_json
+
+          event_json = JSON.parse(event_json_str)
+
+          if result.invoices.present?
+            invoices_data = ::CollectionSerializer.new(
+              result.invoices,
+              ::V1::InvoiceSerializer,
+              collection_name: "invoices",
+            ).to_json
+
+            event_json["event"]["invoices"] = JSON.parse(invoices_data)["invoices"]
+          end
+
+          render(
+            json: event_json,
+          )
+        else
+          render_error_response(result)
+        end
+      end
+
       private
 
       def create_params

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -111,6 +111,39 @@ module Api
         end
       end
 
+      def create_sync
+        customer = Customer.find_or_initialize_by(
+          external_id: create_params[:external_customer_id].to_s.strip,
+          organization_id: current_organization.id,
+        )
+
+        plan = Plan.parents.find_by(
+          code: create_params[:plan_code],
+          organization_id: current_organization.id,
+        )
+
+        result = Subscriptions::CreateSyncService.call(
+          customer:,
+          plan:,
+          params: SubscriptionLegacyInput.new(
+            current_organization,
+            create_params,
+          ).create_input,
+        )
+        debugger
+        if result.success?
+          render(
+          json: ::V1::SubscriptionSerializer.new(
+            result.subscription,
+            root_name: 'subscription',
+            includes: %i[plan invoices],
+          ),
+        )
+        else
+          render_error_response(result)
+        end
+      end
+
       private
 
       def create_params

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -130,7 +130,7 @@ module Api
             create_params,
           ).create_input,
         )
-        debugger
+
         if result.success?
           render(
           json: ::V1::SubscriptionSerializer.new(

--- a/app/jobs/invoices/create_pay_in_advance_sync_charge_job.rb
+++ b/app/jobs/invoices/create_pay_in_advance_sync_charge_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Invoices
+  class CreatePayInAdvanceSyncChargeJob < CreatePayInAdvanceChargeJob
+    def perform(charge:, event:, timestamp:, invoice: nil)
+      result = Invoices::CreatePayInAdvanceChargeSyncService.call(charge:, event:, timestamp:, invoice:)
+      return result if result.success?
+
+      result.raise_if_error! if invoice || result.invoice.nil? || !result.invoice.generating?
+
+      # NOTE: retry the job with the already created invoice in a previous failed attempt
+      self.class.set(wait: 3.seconds).perform_later(
+        charge:,
+        event:,
+        timestamp:,
+        invoice: result.invoice,
+      )
+    end
+  end
+end

--- a/app/serializers/v1/subscription_serializer.rb
+++ b/app/serializers/v1/subscription_serializer.rb
@@ -25,6 +25,7 @@ module V1
 
       payload = payload.merge(customer:) if include?(:customer)
       payload = payload.merge(plan:) if include?(:plan)
+      payload = payload.merge(invoices:) if include?(:invoices)
 
       payload
     end
@@ -44,6 +45,12 @@ module V1
         model.plan,
         includes: %i[charges taxes],
       ).serialize
+    end
+
+    def invoices
+      model.invoices.map do |invoice|
+        ::V1::InvoiceSerializer.new(invoice).serialize
+      end
     end
   end
 end

--- a/app/services/events/create_sync_service.rb
+++ b/app/services/events/create_sync_service.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Events
+  class CreateSyncService < CreateService
+    def call
+      event = Event.new
+      event.organization_id = organization.id
+      event.code = params[:code]
+      event.transaction_id = params[:transaction_id]
+      event.external_customer_id = params[:external_customer_id]
+      event.external_subscription_id = params[:external_subscription_id]
+      event.properties = params[:properties] || {}
+      event.metadata = metadata || {}
+      event.timestamp = Time.zone.at(params[:timestamp] ? params[:timestamp].to_f : timestamp)
+      event.save!
+
+      result.event = event
+
+      produce_kafka_event(event)
+
+      post_event_result = Events::PostProcessSyncService.call(event:)
+      post_event_result.raise_if_error!
+      result.invoices = post_event_result.invoices
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue ActiveRecord::RecordNotUnique
+      result.single_validation_failure!(field: :transaction_id, error_code: "value_already_exist")
+    end
+  end
+end

--- a/app/services/events/post_process_sync_service.rb
+++ b/app/services/events/post_process_sync_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Events
+  class PostProcessSyncService < PostProcessService
+    private
+
+    def handle_pay_in_advance
+      return unless billable_metric
+      charges.where(invoiceable: false).find_each do |charge|
+        # TODO understand what this does, do we need sync for pay in advance?
+        Fees::CreatePayInAdvanceJob.perform_now(charge:, event:)
+      end
+
+      # NOTE: ensure event is processable
+      return if !billable_metric.count_agg? && event.properties[billable_metric.field_name].nil?
+      invoices = []
+      charges.where(invoiceable: true).find_each do |charge|
+        charge_result = Invoices::CreatePayInAdvanceSyncChargeJob.perform_now(charge:, event:, timestamp: event.timestamp)
+        invoices << charge_result.invoice if charge_result&.success?
+      end
+
+      result.invoices = invoices if invoices.any?
+    end
+  end
+end

--- a/app/services/invoices/create_pay_in_advance_charge_sync_service.rb
+++ b/app/services/invoices/create_pay_in_advance_charge_sync_service.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Invoices
+  class CreatePayInAdvanceChargeSyncService < CreatePayInAdvanceChargeService
+    def call
+      fees = generate_fees
+      return Result.new if fees.none?
+
+      create_generating_invoice unless invoice
+      result.invoice = invoice
+
+      ActiveRecord::Base.transaction do
+        fees.each { |f| f.update!(invoice:) }
+
+        invoice.fees_amount_cents = invoice.fees.sum(:amount_cents)
+        invoice.sub_total_excluding_taxes_amount_cents = invoice.fees_amount_cents
+        Credits::AppliedCouponsService.call(invoice:) if invoice.fees_amount_cents&.positive?
+
+        Invoices::ComputeAmountsFromFees.call(invoice:)
+        create_credit_note_credit if credit_notes.any?
+        create_applied_prepaid_credit if should_create_applied_prepaid_credit?
+
+        invoice.payment_status = invoice.total_amount_cents.positive? ? :pending : :succeeded
+        invoice.finalized!
+      end
+
+      track_invoice_created(invoice)
+
+      deliver_webhooks if should_deliver_webhook?
+      InvoiceMailer.with(invoice:).finalized.deliver_later if should_deliver_email?
+      Invoices::Payments::CreateSyncService.new(invoice).call
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    rescue Sequenced::SequenceError
+      raise
+    rescue StandardError => e
+      result.fail_with_error!(e)
+    end
+  end
+end

--- a/app/services/invoices/payments/create_sync_service.rb
+++ b/app/services/invoices/payments/create_sync_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Invoices
+  module Payments
+    class CreateSyncService < CreateService
+      def call
+        case payment_provider
+        when :stripe
+          Invoices::Payments::StripeCreateJob.perform_now(invoice)
+        when :gocardless
+          Invoices::Payments::GocardlessCreateJob.perform_now(invoice)
+        when :adyen
+          Invoices::Payments::AdyenCreateJob.perform_now(invoice)
+        end
+      end
+    end
+  end
+end

--- a/app/services/invoices/subscription_sync_service.rb
+++ b/app/services/invoices/subscription_sync_service.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Invoices
+  class SubscriptionSyncService < SubscriptionService
+    def create
+      active_subscriptions = subscriptions.select(&:active?)
+      return result if active_subscriptions.empty? && recurring
+
+      result = nil
+      invoice = nil
+
+      ActiveRecord::Base.transaction do
+        invoice = Invoice.create!(
+          organization: customer.organization,
+          customer:,
+          issuing_date:,
+          payment_due_date:,
+          net_payment_term: customer.applicable_net_payment_term,
+          invoice_type: :subscription,
+          currency:,
+          timezone: customer.applicable_timezone,
+          status: invoice_status,
+        )
+
+        result = Invoices::CalculateFeesService.new(
+          invoice:,
+          subscriptions: recurring ? active_subscriptions : subscriptions,
+          timestamp:,
+          recurring:,
+        ).call
+
+        result.raise_if_error!
+      end
+
+      if grace_period?
+        SendWebhookJob.perform_later('invoice.drafted', invoice) if should_deliver_webhook?
+      else
+        SendWebhookJob.perform_later('invoice.created', invoice) if should_deliver_webhook?
+        InvoiceMailer.with(invoice:).finalized.deliver_later if should_deliver_finalized_email?
+        Invoices::Payments::CreateSyncService.new(invoice).call
+        track_invoice_created(invoice)
+      end
+
+      result
+    rescue ActiveRecord::RecordInvalid => e
+      result.record_validation_failure!(record: e.record)
+    end
+  end
+end

--- a/app/services/subscriptions/create_sync_service.rb
+++ b/app/services/subscriptions/create_sync_service.rb
@@ -1,0 +1,44 @@
+module Subscriptions
+  class CreateSyncService < CreateService
+    private
+
+    def create_subscription
+      new_subscription = Subscription.new(
+        customer:,
+        plan: params.key?(:plan_overrides) ? override_plan(plan) : plan,
+        subscription_at:,
+        name:,
+        external_id:,
+        billing_time: billing_time || :calendar,
+        ending_at: params[:ending_at],
+      )
+
+      if new_subscription.subscription_at > Time.current
+        new_subscription.pending!
+      elsif new_subscription.subscription_at < Time.current
+        new_subscription.mark_as_active!(new_subscription.subscription_at)
+      else
+        new_subscription.mark_as_active!
+      end
+
+      if new_subscription.active? && new_subscription.subscription_at.today? && plan.pay_in_advance?
+        # TODO
+        # before it was: perform_later(job_class: BillSubscriptionJob, arguments: [[new_subscription], Time.zone.now.to_i])
+        # Have to handle retry logic same as in BillSubscriptionJob
+        result = Invoices::SubscriptionSyncService.new(
+          subscriptions: [new_subscription],
+          timestamp:  Time.zone.now.to_i,
+          recurring: false,
+        ).create
+
+        result.raise_if_error!
+      end
+
+      if new_subscription.active?
+        perform_later(job_class: SendWebhookJob, arguments: ['subscription.started', new_subscription])
+      end
+
+      new_subscription
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,9 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :subscriptions, only: %i[create update show index], param: :external_id
+      resources :subscriptions, only: %i[create update show index], param: :external_id do
+        post :sync, on: :collection, to: 'subscriptions#create_sync'
+      end
       delete '/subscriptions/:external_id', to: 'subscriptions#terminate', as: :terminate
 
       resources :add_ons, param: :code
@@ -53,6 +55,7 @@ Rails.application.routes.draw do
       end
       resources :events, only: %i[create show] do
         post :estimate_fees, on: :collection
+        post :sync, on: :collection, to: 'events#create_sync'
       end
       resources :applied_coupons, only: %i[create index]
       resources :fees, only: %i[show update index]


### PR DESCRIPTION
## What
- Ticket #8 #10

## How 
-  Inherit from an existing service that supports async flow and override it to support synchronous flow.

## How to test
- API to add a subscription with sync mode
```cURL
curl --location '$LAGO_URL/api/v1/subscriptions/sync' \
--header 'Authorization: Bearer $API_KEY' \
--header 'Content-Type: application/json' \
--data '{
    "subscription": {
        "external_customer_id": "stripe_1",
        "external_id": "11111",
        "plan_code": "weekly_7",
        "subscription_at": "2023-12-26T00:00:00Z",
        "billing_time": "anniversary"
    }
}'
```

- API to add a event charge with sync mode
```cURL
curl --location '$LAGO_URL/api/v1/events/sync' \
--header 'Authorization: Bearer $API_KEY' \
--header 'Content-Type: application/json' \
--data '{
    "event": {
      "transaction_id": "transaction_703_616", 
      "external_subscription_id": "aa5861d6-97c6-4802-a256-f773ffc7f3ca",
      "external_customer_id": "adyen_2", 
      "code": "news", 
      "timestamp": 1703642464,
      "properties":  { 
        "article": "49",
        "category": "Society"
      }
    }
  }'
```

