### PR TITLE
Fix/fix subscription sync invoice generating

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -531,6 +531,7 @@ GEM
 PLATFORMS
   aarch64-linux
   aarch64-linux-musl
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-21
   x86_64-darwin-22

--- a/app/services/subscriptions/create_sync_service.rb
+++ b/app/services/subscriptions/create_sync_service.rb
@@ -25,11 +25,11 @@ module Subscriptions
         # TODO
         # before it was: perform_later(job_class: BillSubscriptionJob, arguments: [[new_subscription], Time.zone.now.to_i])
         # Have to handle retry logic same as in BillSubscriptionJob
-        result = Invoices::SubscriptionSyncService.new(
+        result = Invoices::SubscriptionSyncService.call(
           subscriptions: [new_subscription],
           timestamp: Time.zone.now.to_i,
           recurring: false,
-        ).create
+        )
 
         result.raise_if_error!
       end


### PR DESCRIPTION
# What

- Fix `subscription/sync` api bug due to missing fields
- How: adjust `app/services/invoices/subscription_sync_service.rb` create function since its parent SubscriptionService is modified by PR #1561:

https://github.com/getlago/lago-api/pull/1561

# Screenshots

Bugs recorded when calling POST`subscription/sync` api

![image](https://github.com/getlago/lago-api/assets/69509154/e400e657-8cf4-45ff-86d2-459f3ce14165)

![image](https://github.com/getlago/lago-api/assets/69509154/62bbae86-eaa5-4876-92e6-83c432610dc9)
