### PR TITLE
Integrate transaction api

### DIFF
--- a/app/jobs/invoices/payments/pinet_create_job.rb
+++ b/app/jobs/invoices/payments/pinet_create_job.rb
@@ -8,7 +8,7 @@ module Invoices
       unique :until_executed
 
       def perform(invoice)
-        result = Invoices::Payments::PinetService.new(invoice).create
+        result = Invoices::Payments::PinetService.new(invoice:).create
         result.raise_if_error!
       end
     end

--- a/app/services/invoices/payments/create_sync_service.rb
+++ b/app/services/invoices/payments/create_sync_service.rb
@@ -12,7 +12,8 @@ module Invoices
         when :adyen
           Invoices::Payments::AdyenCreateJob.perform_now(invoice)
         when :pinet
-          Invoices::Payments::PinetCreateJob.perform_now(invoice)
+          result = Invoices::Payments::PinetService.new(invoice:, is_sync: true).create
+          result.raise_if_error!
         end
       end
     end

--- a/lib/pinet/client.rb
+++ b/lib/pinet/client.rb
@@ -27,7 +27,7 @@ module Pinet
           transaction: {
             amount: payload[:amount],
             currency: payload[:currency],
-            payment_token: payload[:payment_token] + 'invalid',
+            payment_token: payload[:payment_token],
             description: payload[:description],
           },
         }.to_json

--- a/lib/pinet/client.rb
+++ b/lib/pinet/client.rb
@@ -2,26 +2,81 @@
 
 module Pinet
   class Client
-    PINET_API_URL = ENV.fetch('PINET_API_URL', 'https://api.pinpayments.com/1/charges')
+    PINET_API_URL = ENV.fetch('PINET_API_URL')
+    RETRY_INTERVAL = 0.5 # seconds
+    TIMEOUT = 5 # seconds
 
-    def initialize(api_key: nil)
-      @api_key = api_key
+    def initialize(is_sync: false)
+      @authorization_token = JwtService.create_jwt
+      @is_sync = is_sync
     end
 
     def conn
-      @conn ||= Faraday.new
+      @conn ||= Faraday.new(url: PINET_API_URL) do |faraday|
+        faraday.headers['Authorization'] = "Bearer #{@authorization_token}"
+        faraday.request(:url_encoded)
+        faraday.adapter(Faraday.default_adapter)
+      end
     end
 
-    def charge(charge_body)
-      # Fake response for testing purposes
-      OpenStruct.new(
-        {
-          id: SecureRandom.uuid,
-          amount: charge_body[:amount],
-          currency: charge_body[:currency],
-          status: 'succeeded',
-        },
-      )
+    def charge(payload)
+      response = conn.post do |req|
+        req.url('/api/v1/transactions.json')
+        req.headers['Content-Type'] = 'application/json'
+        req.body = {
+          transaction: {
+            amount: payload[:amount],
+            currency: payload[:currency],
+            payment_token: payload[:payment_token] + 'invalid',
+            description: payload[:description],
+          },
+        }.to_json
+      end
+
+      result = JSON.parse(response.body)
+
+      return handle_transaction_result(result, 'failed') unless response.status == 201
+      return handle_transaction_result(result) unless result['state'] == 'requested' && @is_sync
+
+      transaction = retrieve_transaction(result['id'])
+      handle_transaction_result(transaction)
+    end
+
+    private
+
+    def retrieve_transaction(transaction_id)
+      start_time = Time.now.utc.to_i
+      transaction = nil
+
+      loop do
+        sleep(RETRY_INTERVAL)
+
+        response = conn.get do |req|
+          req.url("/api/v1/transactions/#{transaction_id}.json")
+          req.headers['Content-Type'] = 'application/json'
+        end
+
+        result = JSON.parse(response.body)
+        return result if response.status == 200 && %w[completed failed].include?(result['state'])
+
+        transaction = result if response.status == 200
+
+        break if Time.now.utc.to_i - start_time >= TIMEOUT
+      end
+
+      transaction
+    end
+
+    def handle_transaction_result(transaction_json, created_status = nil)
+      created_status ||= transaction_json['state']
+      raise StandardError, transaction_json['error'] || transaction_json if created_status == 'failed'
+
+      {
+        id: transaction_json['id'],
+        amount: transaction_json['amount'],
+        currency: transaction_json['currency'],
+        status: transaction_json['state'],
+      }
     end
   end
 end

--- a/lib/pinet/client.rb
+++ b/lib/pinet/client.rb
@@ -2,7 +2,7 @@
 
 module Pinet
   class Client
-    PINET_API_URL = ENV.fetch('PINET_API_URL')
+    PINET_API_URL = ENV.fetch('PINET_API_URL', 'default')
     RETRY_INTERVAL = 0.5 # seconds
     TIMEOUT = 5 # seconds
 

--- a/lib/pinet/jwt_service.rb
+++ b/lib/pinet/jwt_service.rb
@@ -1,0 +1,25 @@
+require 'jwt'
+
+module Pinet
+  class JwtService
+    EXPIRATION_PERIOD = 3600 # unit: seconds
+
+    def self.create_jwt
+      iat = Time.now.utc.to_i
+      exp = iat + EXPIRATION_PERIOD
+
+      payload = {
+        'iss' => ENV['MEMBERSHIP_ORG_ID'],
+        'sub' => ENV['PUBLISHER_ID'],
+        'iat' => iat,
+        'exp' => exp,
+      }
+
+      private_key = OpenSSL::PKey::RSA.new(ENV['PUBLISHER_PRIVATE_KEY_FROM_JSON'])
+      kid = ENV['PUBLISHER_PRIVATE_KEY_ID_FROM_JSON']
+
+      additional_headers = { 'kid' => kid }
+      JWT.encode(payload, private_key, 'RS256', additional_headers)
+    end
+  end
+end

--- a/spec/jobs/invoices/payments/pinet_create_job_spec.rb
+++ b/spec/jobs/invoices/payments/pinet_create_job_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe Invoices::Payments::PinetCreateJob, type: :job do
 
   let(:pinet_service) { instance_double(Invoices::Payments::PinetService) }
 
-  it 'calls the stripe create service' do
+  it 'calls the pinet create service' do
     allow(Invoices::Payments::PinetService).to receive(:new)
-      .with(invoice)
+      .with(invoice:)
       .and_return(pinet_service)
     allow(pinet_service).to receive(:create)
       .and_return(BaseService::Result.new)

--- a/spec/services/invoices/payments/pinet_service_spec.rb
+++ b/spec/services/invoices/payments/pinet_service_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Invoices::Payments::PinetService, type: :service do
-  subject(:pinet_service) { described_class.new(invoice) }
+  subject(:pinet_service) { described_class.new(invoice:) }
 
   let(:customer) { create(:customer) }
   let(:organization) { customer.organization }


### PR DESCRIPTION
## What
- Integrate with transaction api (replace mock api).
- Below is the diagram describing the integration flow in cases of both sync and async scenarios
    + Sync: Lago will retrieve transactions every 0.5s with a timeout set to 5s.
    + Async: use background job to call transaction api
<img width="1048" alt="image" src="https://github.com/Pressingly/lagu-api/assets/45629756/469d867e-70af-474d-b17d-effb3cc13508">
<img width="1033" alt="image" src="https://github.com/Pressingly/lagu-api/assets/45629756/08f25bcb-56fb-4eea-8c9c-c3c616031127">
