### PR TITLE
Refactor group charge tables

### DIFF
--- a/app/models/usage_charge_group.rb
+++ b/app/models/usage_charge_group.rb
@@ -11,7 +11,6 @@ class UsageChargeGroup < ApplicationRecord
   # TODO: add details validations
   validates :current_package_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
   validates :available_group_usage, presence: true
-  validates :properties, presence: true
   validates :charge_group_id, presence: true
   validates :subscription_id, presence: true
 end

--- a/app/services/charges/charge_models/package_group_service.rb
+++ b/app/services/charges/charge_models/package_group_service.rb
@@ -50,7 +50,7 @@ module Charges
             free_units: BigDecimal(free_units).to_s,
             paid_units: '0.0',
             per_package_size:,
-            per_package_unit_amount:,
+            per_package_unit_amount: per_group_package_unit_amount,
           }
         end
 
@@ -58,8 +58,12 @@ module Charges
           free_units: BigDecimal(free_units).to_s,
           paid_units: BigDecimal(paid_units).to_s,
           per_package_size:,
-          per_package_unit_amount:,
+          per_package_unit_amount: per_group_package_unit_amount,
         }
+      end
+
+      def charge_group
+        @charge_group ||= ChargeGroup.find(charge.charge_group_id)
       end
 
       def usage_charge_group
@@ -85,7 +89,7 @@ module Charges
       end
 
       def per_group_package_unit_amount
-        @per_group_package_unit_amount ||= BigDecimal(usage_charge_group.properties['amount'])
+        @per_group_package_unit_amount ||= BigDecimal(charge_group.properties['amount'])
       end
 
       def paid_units
@@ -98,10 +102,6 @@ module Charges
 
       def per_package_size
         @per_package_size ||= properties['package_size']
-      end
-
-      def per_package_unit_amount
-        @per_package_unit_amount ||= BigDecimal(properties['amount'])
       end
 
       def current_package_available_usage

--- a/db/migrate/20240229100439_add_columns_to_charge_groups.rb
+++ b/db/migrate/20240229100439_add_columns_to_charge_groups.rb
@@ -3,10 +3,10 @@
 class AddColumnsToChargeGroups < ActiveRecord::Migration[7.0]
   def change
     change_table :charge_groups, bulk: true do |t|
-      t.add_column :pay_in_advance, :boolean, default: false, null: false
-      t.add_column :min_amount_cents, :bigint, default: 0, null: false
-      t.add_column :invoiceable, :boolean, default: true, null: false
-      t.add_column :invoice_display_name, :string
+      t.boolean :pay_in_advance, default: false, null: false
+      t.bigint :min_amount_cents, default: 0, null: false
+      t.boolean :invoiceable, default: true, null: false
+      t.string :invoice_display_name
     end
   end
 end

--- a/db/migrate/20240307050020_remove_properties_from_usage_charge_groups.rb
+++ b/db/migrate/20240307050020_remove_properties_from_usage_charge_groups.rb
@@ -1,0 +1,5 @@
+class RemovePropertiesFromUsageChargeGroups < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :usage_charge_groups, :properties, :jsonb
+  end
+end

--- a/db/migrate/20240307050020_remove_properties_from_usage_charge_groups.rb
+++ b/db/migrate/20240307050020_remove_properties_from_usage_charge_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemovePropertiesFromUsageChargeGroups < ActiveRecord::Migration[7.0]
   def change
     remove_column :usage_charge_groups, :properties, :jsonb

--- a/db/migrate/20240307050026_add_properties_to_charge_groups.rb
+++ b/db/migrate/20240307050026_add_properties_to_charge_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPropertiesToChargeGroups < ActiveRecord::Migration[7.0]
   def change
     add_column :charge_groups, :properties, :jsonb, null: false, default: {}

--- a/db/migrate/20240307050026_add_properties_to_charge_groups.rb
+++ b/db/migrate/20240307050026_add_properties_to_charge_groups.rb
@@ -1,0 +1,5 @@
+class AddPropertiesToChargeGroups < ActiveRecord::Migration[7.0]
+  def change
+    add_column :charge_groups, :properties, :jsonb, null: false, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_29_100439) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_07_050026) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -171,6 +171,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_29_100439) do
     t.bigint "min_amount_cents", default: 0, null: false
     t.boolean "invoiceable", default: true, null: false
     t.string "invoice_display_name"
+    t.jsonb "properties", default: {}, null: false
   end
 
   create_table "charges", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -820,7 +821,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_29_100439) do
   create_table "usage_charge_groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "current_package_count", default: 1, null: false
     t.jsonb "available_group_usage"
-    t.jsonb "properties", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"


### PR DESCRIPTION
## Description
- Move `properties` column from `usage_charge_group` to `charge_group` table for more precise table relationship.
- This PR is a fix of https://github.com/Pressingly/lagu-api/pull/34
- Fix typo error of `20240229100439_add_columns_to_charge_groups`
