### PR TITLE
Add group charge graphql definition to integrate with lago-front

### DIFF
--- a/app/graphql/mutations/plans/create.rb
+++ b/app/graphql/mutations/plans/create.rb
@@ -21,6 +21,7 @@ module Mutations
       argument :tax_codes, [String], required: false
       argument :trial_period, Float, required: false
 
+      argument :charge_groups, [Types::ChargeGroups::Input], required: false
       argument :charges, [Types::Charges::Input]
 
       type Types::Plans::Object

--- a/app/graphql/types/charge_groups/input.rb
+++ b/app/graphql/types/charge_groups/input.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Types
+  module ChargeGroups
+    class Input < Types::BaseInputObject
+      graphql_name 'ChargeGroupInput'
+
+      argument :id, ID, required: false
+      argument :invoice_display_name, String, required: false
+
+      argument :invoiceable, Boolean, required: false
+      argument :min_amount_cents, GraphQL::Types::BigInt, required: false
+      argument :pay_in_advance, Boolean, required: false
+
+      argument :properties, Types::ChargeGroups::PropertiesInput, required: false
+    end
+  end
+end

--- a/app/graphql/types/charge_groups/object.rb
+++ b/app/graphql/types/charge_groups/object.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Types
+  module ChargeGroups
+    class Object < Types::BaseObject
+      graphql_name 'ChargeGroup'
+
+      field :id, ID, null: false
+      field :invoice_display_name, String, null: true
+
+      field :charges, [Types::Charges::Object]
+      field :usage_charge_groups, [Types::UsageChargeGroups::Object]
+
+      field :invoiceable, Boolean, null: false
+      field :min_amount_cents, GraphQL::Types::BigInt, null: false
+      field :pay_in_advance, Boolean, null: false
+      field :properties, Types::ChargeGroups::Properties, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      # TODO: check if this is needed
+      delegate :charges, to: :object
+      delegate :usage_charge_groups, to: :object
+    end
+  end
+end

--- a/app/graphql/types/charge_groups/properties.rb
+++ b/app/graphql/types/charge_groups/properties.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module ChargeGroups
+    class Properties < Types::BaseObject
+      graphql_name 'ChargeGroupProperties'
+
+      # NOTE: Standard and Package charge model
+      field :amount, String, null: true
+
+      # NOTE: Group package charge model
+      field :free_units, GraphQL::Types::BigInt, null: true
+    end
+  end
+end

--- a/app/graphql/types/charge_groups/properties_input.rb
+++ b/app/graphql/types/charge_groups/properties_input.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Types
+  module ChargeGroups
+    class PropertiesInput < Types::BaseInputObject
+      graphql_name 'ChargeGroupPropertiesInput'
+
+      # NOTE: Standard and Package charge model
+      argument :amount, String, required: false
+
+      # NOTE: Group package charge model
+      argument :free_units, GraphQL::Types::BigInt, required: false
+    end
+  end
+end

--- a/app/graphql/types/charges/input.rb
+++ b/app/graphql/types/charges/input.rb
@@ -6,6 +6,7 @@ module Types
       graphql_name 'ChargeInput'
 
       argument :billable_metric_id, ID, required: true
+      argument :charge_group_id, ID, required: false
       argument :charge_model, Types::Charges::ChargeModelEnum, required: true
       argument :id, ID, required: false
       argument :invoice_display_name, String, required: false

--- a/app/graphql/types/charges/object.rb
+++ b/app/graphql/types/charges/object.rb
@@ -9,6 +9,7 @@ module Types
       field :invoice_display_name, String, null: true
 
       field :billable_metric, Types::BillableMetrics::Object, null: false
+      field :charge_group, Types::ChargeGroups::Object, null: true
       field :charge_model, Types::Charges::ChargeModelEnum, null: false
       field :group_properties, [Types::Charges::GroupProperties], null: true
       field :invoiceable, Boolean, null: false
@@ -33,6 +34,12 @@ module Types
         scope = object.group_properties
         scope = scope.with_discarded if object.discarded?
         scope.includes(:group).sort_by { |gp| gp.group&.name }
+      end
+
+      def charge_group
+        return object.charge_group unless object.discarded?
+
+        ChargeGroup.with_discarded.find_by(id: object.charge_group_id)
       end
     end
   end

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -20,6 +20,7 @@ module Types
       field :pay_in_advance, Boolean, null: false
       field :trial_period, Float
 
+      field :charge_groups, [Types::ChargeGroups::Object]
       field :charges, [Types::Charges::Object]
       field :taxes, [Types::Taxes::Object]
 
@@ -27,6 +28,7 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       field :active_subscriptions_count, Integer, null: false
+      field :charge_groups_count, Integer, null: false, description: 'Number of charge groups attached to a plan'
       field :charges_count, Integer, null: false, description: 'Number of charges attached to a plan'
       field :customers_count, Integer, null: false, description: 'Number of customers attached to a plan'
       field :draft_invoices_count, Integer, null: false
@@ -36,8 +38,16 @@ module Types
         object.charges.order(created_at: :asc)
       end
 
+      def charge_groups
+        object.charge_groups.order(created_at: :asc)
+      end
+
       def charges_count
         object.charges.count
+      end
+
+      def charge_groups_count
+        object.charge_groups.count
       end
 
       def subscriptions_count

--- a/app/graphql/types/usage_charge_groups/object.rb
+++ b/app/graphql/types/usage_charge_groups/object.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Types
+  module UsageChargeGroups
+    class Object < Types::BaseObject
+      graphql_name 'UsageChargeGroup'
+
+      field :id, ID, null: false
+
+      field :charge_group, Types::ChargeGroups::Object, null: false
+      field :subscription, Types::Subscriptions::Object, null: false
+
+      field :available_group_usage, GraphQL::Types::JSON, null: true
+      field :current_package_count, GraphQL::Types::BigInt, null: false
+
+      field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+      field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+
+      # TODO: check if this is needed
+      def charge_group
+        return object.charge_group unless object.discarded?
+
+        ChargeGroup.with_discarded.find_by(id: object.charge_group_id)
+      end
+
+      # TODO: check if this is needed
+      delegate :subscription, to: :object
+    end
+  end
+end

--- a/app/models/charge_group.rb
+++ b/app/models/charge_group.rb
@@ -5,6 +5,8 @@ class ChargeGroup < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
+  belongs_to :plan, -> { with_discarded }, touch: true
+
   has_many :charges
   has_many :usage_charge_groups
 end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -10,6 +10,7 @@ class Plan < ApplicationRecord
   belongs_to :parent, class_name: 'Plan', optional: true
 
   has_many :charges, dependent: :destroy
+  has_many :charge_groups, dependent: :destroy
   has_many :billable_metrics, through: :charges
   has_many :subscriptions
   has_many :customers, through: :subscriptions

--- a/app/models/usage_charge_group.rb
+++ b/app/models/usage_charge_group.rb
@@ -11,7 +11,6 @@ class UsageChargeGroup < ApplicationRecord
   # TODO: add details validations
   validates :current_package_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
   validates :available_group_usage, presence: true
-  validates :properties, presence: true
   validates :charge_group_id, presence: true
   validates :subscription_id, presence: true
 end

--- a/app/services/charges/build_default_properties_service.rb
+++ b/app/services/charges/build_default_properties_service.rb
@@ -15,6 +15,8 @@ module Charges
       when :percentage then default_percentage_properties
       when :volume then default_volume_properties
       when :graduated_percentage then default_graduated_percentage_properties
+      when :package_group then default_package_group_properties
+      when :timebased then default_timebased_properties
       end
     end
 
@@ -75,6 +77,21 @@ module Charges
             'flat_amount': '0',
           },
         ],
+      }
+    end
+
+    def default_package_group_properties
+      {
+        'package_size': 1,
+        'amount': '0',
+        'free_units': 0,
+      }
+    end
+
+    def default_timebased_properties
+      {
+        'amount': '0',
+        'block_time_in_minutes': 15,
       }
     end
   end

--- a/app/services/charges/charge_models/package_group_service.rb
+++ b/app/services/charges/charge_models/package_group_service.rb
@@ -50,7 +50,7 @@ module Charges
             free_units: BigDecimal(free_units).to_s,
             paid_units: '0.0',
             per_package_size:,
-            per_package_unit_amount:,
+            per_package_unit_amount: per_group_package_unit_amount,
           }
         end
 
@@ -58,8 +58,12 @@ module Charges
           free_units: BigDecimal(free_units).to_s,
           paid_units: BigDecimal(paid_units).to_s,
           per_package_size:,
-          per_package_unit_amount:,
+          per_package_unit_amount: per_group_package_unit_amount,
         }
+      end
+
+      def charge_group
+        @charge_group ||= ChargeGroup.find(charge.charge_group_id)
       end
 
       def usage_charge_group
@@ -85,7 +89,7 @@ module Charges
       end
 
       def per_group_package_unit_amount
-        @per_group_package_unit_amount ||= BigDecimal(usage_charge_group.properties['amount'])
+        @per_group_package_unit_amount ||= BigDecimal(charge_group.properties['amount'])
       end
 
       def paid_units
@@ -98,10 +102,6 @@ module Charges
 
       def per_package_size
         @per_package_size ||= properties['package_size']
-      end
-
-      def per_package_unit_amount
-        @per_package_unit_amount ||= BigDecimal(properties['amount'])
       end
 
       def current_package_available_usage

--- a/db/migrate/20240229100439_add_columns_to_charge_groups.rb
+++ b/db/migrate/20240229100439_add_columns_to_charge_groups.rb
@@ -3,10 +3,10 @@
 class AddColumnsToChargeGroups < ActiveRecord::Migration[7.0]
   def change
     change_table :charge_groups, bulk: true do |t|
-      t.add_column :pay_in_advance, :boolean, default: false, null: false
-      t.add_column :min_amount_cents, :bigint, default: 0, null: false
-      t.add_column :invoiceable, :boolean, default: true, null: false
-      t.add_column :invoice_display_name, :string
+      t.boolean :pay_in_advance, default: false, null: false
+      t.bigint :min_amount_cents, default: 0, null: false
+      t.boolean :invoiceable, default: true, null: false
+      t.string :invoice_display_name
     end
   end
 end

--- a/db/migrate/20240307050020_remove_properties_from_usage_charge_groups.rb
+++ b/db/migrate/20240307050020_remove_properties_from_usage_charge_groups.rb
@@ -1,0 +1,5 @@
+class RemovePropertiesFromUsageChargeGroups < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :usage_charge_groups, :properties, :jsonb
+  end
+end

--- a/db/migrate/20240307050020_remove_properties_from_usage_charge_groups.rb
+++ b/db/migrate/20240307050020_remove_properties_from_usage_charge_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemovePropertiesFromUsageChargeGroups < ActiveRecord::Migration[7.0]
   def change
     remove_column :usage_charge_groups, :properties, :jsonb

--- a/db/migrate/20240307050026_add_properties_to_charge_groups.rb
+++ b/db/migrate/20240307050026_add_properties_to_charge_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPropertiesToChargeGroups < ActiveRecord::Migration[7.0]
   def change
     add_column :charge_groups, :properties, :jsonb, null: false, default: {}

--- a/db/migrate/20240307050026_add_properties_to_charge_groups.rb
+++ b/db/migrate/20240307050026_add_properties_to_charge_groups.rb
@@ -1,0 +1,5 @@
+class AddPropertiesToChargeGroups < ActiveRecord::Migration[7.0]
+  def change
+    add_column :charge_groups, :properties, :jsonb, null: false, default: {}
+  end
+end

--- a/db/migrate/20240308081648_add_plan_to_charge_groups.rb
+++ b/db/migrate/20240308081648_add_plan_to_charge_groups.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPlanToChargeGroups < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :charge_groups, :plan, foreign_key: true, type: :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_07_050026) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_08_081648) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -172,6 +172,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_07_050026) do
     t.boolean "invoiceable", default: true, null: false
     t.string "invoice_display_name"
     t.jsonb "properties", default: {}, null: false
+    t.uuid "plan_id"
+    t.index ["plan_id"], name: "index_charge_groups_on_plan_id"
   end
 
   create_table "charges", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -924,6 +926,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_07_050026) do
   add_foreign_key "applied_add_ons", "customers"
   add_foreign_key "billable_metrics", "organizations"
   add_foreign_key "cached_aggregations", "groups"
+  add_foreign_key "charge_groups", "plans"
   add_foreign_key "charges", "billable_metrics"
   add_foreign_key "charges", "charge_groups"
   add_foreign_key "charges", "plans"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_29_100439) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_07_050026) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -171,6 +171,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_29_100439) do
     t.bigint "min_amount_cents", default: 0, null: false
     t.boolean "invoiceable", default: true, null: false
     t.string "invoice_display_name"
+    t.jsonb "properties", default: {}, null: false
   end
 
   create_table "charges", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -820,7 +821,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_29_100439) do
   create_table "usage_charge_groups", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.bigint "current_package_count", default: 1, null: false
     t.jsonb "available_group_usage"
-    t.jsonb "properties", default: {}, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deleted_at"


### PR DESCRIPTION
## Context

We want to integrate lago-front with lagu-api to introduce group package charge feature. This PR is a continuation of https://github.com/Pressingly/lagu-api/pull/34

## Description

- Link `plans` to `charge_groups` table
<img width="736" alt="image" src="https://github.com/Pressingly/lagu-api/assets/69509154/a133b962-0fd1-4669-b332-edae2725d113">

- Update graphql files to define added objects and mutations
- Create `usage_charge_groups` when a `subscription` is created
- Create `charge_groups` when a `plan` is created in lago-front
