### PR TITLE
Add service to create usage_charge_group when add a plan to customer

### DIFF
--- a/app/models/usage_charge_group.rb
+++ b/app/models/usage_charge_group.rb
@@ -10,7 +10,6 @@ class UsageChargeGroup < ApplicationRecord
 
   # TODO: add details validations
   validates :current_package_count, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 1 }
-  validates :available_group_usage, presence: true
   validates :charge_group_id, presence: true
   validates :subscription_id, presence: true
 end

--- a/app/services/subscriptions/create_service.rb
+++ b/app/services/subscriptions/create_service.rb
@@ -42,6 +42,8 @@ module Subscriptions
         return currency_result unless currency_result.success?
 
         result.subscription = handle_subscription
+
+        UsageChargeGroups::CreateService.call(subscription: result.subscription)
       end
 
       perform_pending_jobs

--- a/app/services/usage_charge_groups/create_service.rb
+++ b/app/services/usage_charge_groups/create_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module UsageChargeGroups
+  class CreateService < BaseService
+    def initialize(subscription:)
+      super
+      @subscription = subscription
+    end
+
+    def call
+      is_group_charge?
+      create_usage_charge_group
+    end
+
+    private
+
+    attr_reader :subscription
+
+    delegate :plan, to: :subscription
+
+    def is_group_charge?
+      subscription.plan.charge_groups.present?
+    end
+
+    def create_usage_charge_group
+      plan.charge_groups.each do |charge_group|
+        usage_charge_group = UsageChargeGroup.new(
+          charge_group_id: charge_group.id,
+          subscription_id: subscription.id,
+          current_package_count: 1,
+        )
+        usage_charge_group.available_group_usage = compute_available_group_usage(charge_group)
+        usage_charge_group.save!
+      end
+    end
+
+    def compute_available_group_usage(charge_group)
+      available_group_usage = {}
+      charge_group.charges.package_group.each do |charge|
+        billable_metric = charge.billable_metric
+        available_group_usage[billable_metric.id] = charge.properties['package_size']
+      end
+
+      available_group_usage
+    end
+  end
+end

--- a/app/services/usage_charge_groups/create_service.rb
+++ b/app/services/usage_charge_groups/create_service.rb
@@ -8,8 +8,7 @@ module UsageChargeGroups
     end
 
     def call
-      is_group_charge?
-      create_usage_charge_group
+      create_usage_charge_group if has_group_charge?
     end
 
     private
@@ -18,7 +17,7 @@ module UsageChargeGroups
 
     delegate :plan, to: :subscription
 
-    def is_group_charge?
+    def has_group_charge?
       subscription.plan.charge_groups.present?
     end
 
@@ -29,19 +28,8 @@ module UsageChargeGroups
           subscription_id: subscription.id,
           current_package_count: 1,
         )
-        usage_charge_group.available_group_usage = compute_available_group_usage(charge_group)
         usage_charge_group.save!
       end
-    end
-
-    def compute_available_group_usage(charge_group)
-      available_group_usage = {}
-      charge_group.charges.package_group.each do |charge|
-        billable_metric = charge.billable_metric
-        available_group_usage[billable_metric.id] = charge.properties['package_size']
-      end
-
-      available_group_usage
     end
   end
 end

--- a/db/migrate/20240311122947_add_unique_index_to_usage_charge_group.rb
+++ b/db/migrate/20240311122947_add_unique_index_to_usage_charge_group.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexToUsageChargeGroup < ActiveRecord::Migration[7.0]
+  def change
+    add_index :usage_charge_groups,
+              [:charge_group_id, :subscription_id],
+              unique: true,
+              name: 'index_ucg_on_charge_group_id_and_subscription_id'
+  end
+end

--- a/db/migrate/20240311122947_add_unique_index_to_usage_charge_group.rb
+++ b/db/migrate/20240311122947_add_unique_index_to_usage_charge_group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddUniqueIndexToUsageChargeGroup < ActiveRecord::Migration[7.0]
   def change
     add_index :usage_charge_groups,

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_08_081648) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_11_122947) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -828,6 +828,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_08_081648) do
     t.datetime "deleted_at"
     t.uuid "charge_group_id", null: false
     t.uuid "subscription_id", null: false
+    t.index ["charge_group_id", "subscription_id"], name: "index_ucg_on_charge_group_id_and_subscription_id", unique: true
     t.index ["charge_group_id"], name: "index_usage_charge_groups_on_charge_group_id"
     t.index ["subscription_id"], name: "index_usage_charge_groups_on_subscription_id"
   end


### PR DESCRIPTION
## What
- Added a new service `UsageChargeGroups::CreateService` for generating appropriate `usage charge groups` based on a subscription's plan upon subscription creation.

- Add a **unique index** to usage_charge_groups table on the combination of **charge_group_id** and **subscription_id**.

## Why
- To ensure that the system accurately creates usage charge group.

## Screenshot
- Create success:
<img width="1331" alt="image" src="https://github.com/Pressingly/lagu-api/assets/45629756/a53e734f-ba65-46a3-8b5b-6e6493cbc8c7">
