### PR TITLE
Fix graphql and plans/update_service to allow edit plans with charge_groups

### DIFF
--- a/app/graphql/mutations/plans/update.rb
+++ b/app/graphql/mutations/plans/update.rb
@@ -21,6 +21,7 @@ module Mutations
       argument :tax_codes, [String], required: false
       argument :trial_period, Float, required: false
 
+      argument :charge_groups, [Types::ChargeGroups::Input], required: false
       argument :charges, [Types::Charges::Input]
 
       type Types::Plans::Object

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -28,26 +28,25 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       field :active_subscriptions_count, Integer, null: false
-      field :charge_groups_count, Integer, null: false, description: 'Number of charge groups attached to a plan'
       field :charges_count, Integer, null: false, description: 'Number of charges attached to a plan'
       field :customers_count, Integer, null: false, description: 'Number of customers attached to a plan'
       field :draft_invoices_count, Integer, null: false
       field :subscriptions_count, Integer, null: false
 
       def charges
-        object.charges.order(created_at: :asc)
+        return object.charges.order(created_at: :asc) unless object.discarded?
+
+        Charge.with_discarded.find_by(id: object.charge_id)
       end
 
       def charge_groups
-        object.charge_groups.order(created_at: :asc)
+        return object.charge_groups.order(created_at: :asc) unless object.discarded?
+
+        ChargeGroup.with_discarded.find_by(id: object.charge_group_id)
       end
 
       def charges_count
-        object.charges.count
-      end
-
-      def charge_groups_count
-        object.charge_groups.count
+        object.charge_groups.count + object.charges.where(charge_group_id: nil).count
       end
 
       def subscriptions_count

--- a/app/graphql/types/plans/object.rb
+++ b/app/graphql/types/plans/object.rb
@@ -28,6 +28,7 @@ module Types
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
       field :active_subscriptions_count, Integer, null: false
+      field :charge_groups_count, Integer, null: false, description: 'Number of charge groups attached to a plan'
       field :charges_count, Integer, null: false, description: 'Number of charges attached to a plan'
       field :customers_count, Integer, null: false, description: 'Number of customers attached to a plan'
       field :draft_invoices_count, Integer, null: false
@@ -46,7 +47,11 @@ module Types
       end
 
       def charges_count
-        object.charge_groups.count + object.charges.where(charge_group_id: nil).count
+        object.charges.count
+      end
+
+      def charge_groups_count
+        object.charge_groups.count
       end
 
       def subscriptions_count

--- a/app/graphql/types/usage_charge_groups/object.rb
+++ b/app/graphql/types/usage_charge_groups/object.rb
@@ -17,14 +17,12 @@ module Types
       field :deleted_at, GraphQL::Types::ISO8601DateTime, null: true
       field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
 
-      # TODO: check if this is needed
       def charge_group
         return object.charge_group unless object.discarded?
 
         ChargeGroup.with_discarded.find_by(id: object.charge_group_id)
       end
 
-      # TODO: check if this is needed
       delegate :subscription, to: :object
     end
   end

--- a/app/models/charge.rb
+++ b/app/models/charge.rb
@@ -8,7 +8,7 @@ class Charge < ApplicationRecord
 
   belongs_to :plan, -> { with_discarded }, touch: true
   belongs_to :billable_metric, -> { with_discarded }
-  belongs_to :charge_group, optional: true
+  belongs_to :charge_group, -> { with_discarded }, optional: true
 
   has_many :fees
   has_many :group_properties, dependent: :destroy

--- a/app/models/charge_group.rb
+++ b/app/models/charge_group.rb
@@ -9,4 +9,6 @@ class ChargeGroup < ApplicationRecord
 
   has_many :charges, dependent: :destroy
   has_many :usage_charge_groups, dependent: :destroy
+
+  default_scope -> { kept }
 end

--- a/app/models/charge_group.rb
+++ b/app/models/charge_group.rb
@@ -7,6 +7,6 @@ class ChargeGroup < ApplicationRecord
 
   belongs_to :plan, -> { with_discarded }, touch: true
 
-  has_many :charges
-  has_many :usage_charge_groups
+  has_many :charges, dependent: :destroy
+  has_many :usage_charge_groups, dependent: :destroy
 end

--- a/app/models/usage_charge_group.rb
+++ b/app/models/usage_charge_group.rb
@@ -5,7 +5,7 @@ class UsageChargeGroup < ApplicationRecord
   include Discard::Model
   self.discard_column = :deleted_at
 
-  belongs_to :charge_group
+  belongs_to :charge_group, -> { with_discarded }
   belongs_to :subscription
 
   # TODO: add details validations

--- a/app/services/charge_groups/build_default_properties_service.rb
+++ b/app/services/charge_groups/build_default_properties_service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ChargeGroups
+  class BuildDefaultPropertiesService < BaseService
+    def call
+      default_charge_group_properties
+    end
+
+    private
+
+    def default_charge_group_properties
+      { 'amount': '0' }
+    end
+  end
+end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -43,6 +43,7 @@ module Plans
         end
 
         process_charges(plan, params[:charges]) if params[:charges]
+        process_charge_groups(plan, params[:charge_groups]) if params[:charge_groups]
       end
 
       result.plan = plan
@@ -165,6 +166,69 @@ module Plans
       charge.group_properties.discard_all
 
       Invoice.where(id: draft_invoice_ids).update_all(ready_to_be_refreshed: true) # rubocop:disable Rails/SkipsModelValidations
+    end
+
+    def process_charge_groups(plan, params_charge_groups)
+      created_charge_groups_ids = []
+
+      hash_charge_groups = params_charge_groups.map { |c| c.to_h.deep_symbolize_keys }
+      hash_charge_groups.each do |payload_charge_group|
+        charge_group = plan.charge_groups.find_by(id: payload_charge_group[:id])
+
+        if charge_group
+          properties = payload_charge_group.delete(:properties)
+          charge_group.update!(
+            invoice_display_name: payload_charge_group[:invoice_display_name],
+            properties: properties.presence || ChargeGroups::BuildDefaultPropertiesService.call,
+          )
+
+          # NOTE: charge groups cannot be edited if plan is attached to a subscription
+          unless plan.attached_to_subscriptions?
+            invoiceable = payload_charge_group.delete(:invoiceable)
+            min_amount_cents = payload_charge_group.delete(:min_amount_cents)
+
+            charge_group.invoiceable = invoiceable if License.premium? && !invoiceable.nil?
+            charge_group.min_amount_cents = min_amount_cents || 0 if License.premium?
+
+            charge_group.update!(payload_charge_group)
+            charge_group
+          end
+
+          next
+        end
+
+        created_charge_group = create_charge_group(plan, payload_charge_group)
+        created_charge_groups_ids.push(created_charge_group.id)
+      end
+
+      # NOTE: Delete charge groups that are no more linked to the plan
+      sanitize_charge_groups(plan, hash_charge_groups, created_charge_groups_ids)
+    end
+
+    def create_charge_group(plan, params)
+      charge_group = plan.charge_groups.new(
+        invoice_display_name: params[:invoice_display_name],
+        # NOTE: charge group is pay in advance by default since pay in arrears is not implemented yet
+        pay_in_advance: params[:pay_in_advance] || true,
+        properties: params[:properties].presence || Charges::BuildDefaultPropertiesService.call(charge_model(params)),
+      )
+
+      if License.premium?
+        charge_group.invoiceable = params[:invoiceable] unless params[:invoiceable].nil?
+        charge_group.min_amount_cents = params[:min_amount_cents] || 0
+      end
+      charge_group.save!
+      charge_group
+    end
+
+    def sanitize_charge_groups(plan, args_charge_groups, created_charge_groups_ids)
+      args_charge_groups_ids = args_charge_groups.map { |c| c[:id] }.compact
+      charge_groups_ids = plan.charge_groups.pluck(:id) - args_charge_groups_ids - created_charge_groups_ids
+      plan.charge_groups.where(id: charge_groups_ids).find_each { |charge_group| discard_charge_group!(charge_group) }
+    end
+
+    def discard_charge_group!(charge_group)
+      charge_group.discard!
     end
   end
 end

--- a/app/services/plans/update_service.rb
+++ b/app/services/plans/update_service.rb
@@ -223,13 +223,10 @@ module Plans
         invoice_display_name: params[:invoice_display_name],
         # NOTE: charge group is pay in advance by default since pay in arrears is not implemented yet
         pay_in_advance: params[:pay_in_advance] || true,
-        properties: params[:properties].presence || Charges::BuildDefaultPropertiesService.call(charge_model(params)),
+        properties: params[:properties].presence || ChargeGroups::BuildDefaultPropertiesService.call,
+        invoiceable: params[:invoiceable] || true,
+        min_amount_cents: params[:min_amount_cents] || 0,
       )
-
-      if License.premium?
-        charge_group.invoiceable = params[:invoiceable] unless params[:invoiceable].nil?
-        charge_group.min_amount_cents = params[:min_amount_cents] || 0
-      end
 
       charge_group.save!
       charge_group


### PR DESCRIPTION
## Description

- Implement `plans/update_service.rb` to create/update/delete charge_groups table.
- Fix graphql definition to allow edit plan on lago-front
