### PR TITLE
Fix charge group feature

### DIFF
--- a/app/services/charges/charge_models/package_timebased_group_service.rb
+++ b/app/services/charges/charge_models/package_timebased_group_service.rb
@@ -45,7 +45,7 @@ module Charges
       def initial_group_units
         # Check how many packages (groups of units) are consumed
         # For the first time, it's rounded up, because a group counts from its first unit
-        paid_units.fdiv(per_package_size).ceil
+        paid_units.fdiv(per_package_size).to_i
       end
 
       def group_usage

--- a/app/services/charges/charge_models/package_timebased_group_service.rb
+++ b/app/services/charges/charge_models/package_timebased_group_service.rb
@@ -70,8 +70,9 @@ module Charges
       end
 
       def reset_available_group_usage(init_pacakge_size = nil)
-        available_group_usage = {}
+        return unless usage_charge_group
 
+        available_group_usage = {}
         usage_charge_group.charge_group.charges.package_group.each do |child_charge|
           available_group_usage[child_charge.billable_metric_id] = child_charge.properties['package_size']
         end

--- a/app/services/charges/charge_models/package_timebased_group_service.rb
+++ b/app/services/charges/charge_models/package_timebased_group_service.rb
@@ -43,7 +43,9 @@ module Charges
       end
 
       def initial_group_units
-        paid_units.fdiv(per_package_size).to_i
+        return 0 if paid_units <= per_package_size
+
+        paid_units.fdiv(per_package_size).ceil
       end
 
       def group_usage

--- a/app/services/charges/charge_models/package_timebased_group_service.rb
+++ b/app/services/charges/charge_models/package_timebased_group_service.rb
@@ -43,8 +43,6 @@ module Charges
       end
 
       def initial_group_units
-        # Check how many packages (groups of units) are consumed
-        # For the first time, it's rounded up, because a group counts from its first unit
         paid_units.fdiv(per_package_size).to_i
       end
 

--- a/app/services/charges/charge_models/timebased_service.rb
+++ b/app/services/charges/charge_models/timebased_service.rb
@@ -24,11 +24,25 @@ module Charges
       end
 
       def per_package_unit_amount
-        @per_package_unit_amount ||= BigDecimal(properties['amount'])
+        @per_package_unit_amount ||= if is_in_group_charge?
+          per_group_package_unit_amount
+        else
+          BigDecimal(properties['amount'])
+        end
       end
 
       def paid_units
         @paid_units ||= units
+      end
+
+      private
+
+      def is_in_group_charge?
+        charge.charge_group_id.present?
+      end
+
+      def per_group_package_unit_amount
+        @per_group_package_unit_amount ||= BigDecimal(charge.charge_group.properties['amount'])
       end
     end
   end

--- a/app/services/charges/charge_models/timebased_service.rb
+++ b/app/services/charges/charge_models/timebased_service.rb
@@ -24,7 +24,7 @@ module Charges
       end
 
       def per_package_unit_amount
-        @per_package_unit_amount ||= if is_in_group_charge?
+        @per_package_unit_amount ||= if charge_belongs_to_group?
           per_group_package_unit_amount
         else
           BigDecimal(properties['amount'])
@@ -37,7 +37,7 @@ module Charges
 
       private
 
-      def is_in_group_charge?
+      def charge_belongs_to_group?
         charge.charge_group_id.present?
       end
 

--- a/app/services/events/stores/postgres_store.rb
+++ b/app/services/events/stores/postgres_store.rb
@@ -166,7 +166,7 @@ module Events
         billable_metric = event.organization.billable_metrics.find_by(code: event.code)
         charge = Charge.where(plan:, billable_metric:).first
 
-        UsageChargeGroup.find_by(subscription_id: subscription.id, charge_group_id: charge.charge_group_id)
+        UsageChargeGroup.find_by(subscription_id: subscription.id, charge_group_id: charge&.charge_group_id)
       end
     end
   end


### PR DESCRIPTION
## What
- Fix error in `TimebasedService`:
  - When `timesbased` charge is belongs to a charge_group, the amount should get from `propertices` of charge_group. 

#### Fix PackageTimebasedGroupService
 Use `.to_i` instead of `.ceil` to calculate `initial_group_units` in service `PackageTimebasedGroupService`
- Package: 4 articles & 5 minutes, cost $3.
- There is a case when:
  - paid_units = 2 and per_package_size = 4
  Expected `initial_group_units = 0`
  - When use `.ceil` --> `initial_group_units = 1` --> user will be charged
  - Should use `.to_i` --> `initial_group_units = 0` --> not charge user

## Why
- Handle case usage_charge_group not found
<img width="1084" alt="image" src="https://github.com/Pressingly/lagu-api/assets/45629756/de4cc176-7161-4bdd-a241-505e9b89ae6b">
