### PR TITLE
Pinet Integration by using API certificate (private_key, key_id)

### DIFF
--- a/app/graphql/types/payment_providers/pinet.rb
+++ b/app/graphql/types/payment_providers/pinet.rb
@@ -6,7 +6,9 @@ module Types
       graphql_name 'PinetProvider'
 
       field :id, ID, null: false
-      field :secret_key, String, null: false
+      field :key_id, String, null: false
+      field :private_key, String, null: false
+      field :secret_key, String, null: true
 
       field :create_customers, Boolean, null: false
       field :success_redirect_url, String, null: true
@@ -15,6 +17,14 @@ module Types
       #       front end application. Instead we send an obfuscated value
       def secret_key
         "#{'•' * 8}…#{object.secret_key[-3..]}"
+      end
+
+      def key_id
+        "#{'•' * 8}…#{object.key_id[-3..]}"
+      end
+
+      def private_key
+        "#{'•' * 8}…#{object.private_key[-3..]}"
       end
     end
   end

--- a/app/graphql/types/payment_providers/pinet.rb
+++ b/app/graphql/types/payment_providers/pinet.rb
@@ -8,16 +8,8 @@ module Types
       field :id, ID, null: false
       field :key_id, String, null: false
       field :private_key, String, null: false
-      field :secret_key, String, null: true
 
-      field :create_customers, Boolean, null: false
       field :success_redirect_url, String, null: true
-
-      # NOTE: Secret key is a sensitive information. It should not be sent back to the
-      #       front end application. Instead we send an obfuscated value
-      def secret_key
-        "#{'•' * 8}…#{object.secret_key[-3..]}"
-      end
 
       def key_id
         "#{'•' * 8}…#{object.key_id[-3..]}"

--- a/app/graphql/types/payment_providers/pinet_input.rb
+++ b/app/graphql/types/payment_providers/pinet_input.rb
@@ -8,6 +8,9 @@ module Types
       argument :create_customers, Boolean, required: false
       argument :secret_key, String, required: false
       argument :success_redirect_url, String, required: false
+
+      argument :key_id, String, required: true
+      argument :private_key, String, required: true
     end
   end
 end

--- a/app/models/payment_providers/pinet_provider.rb
+++ b/app/models/payment_providers/pinet_provider.rb
@@ -29,5 +29,21 @@ module PaymentProviders
     def webhook_id
       get_from_settings('webhook_id')
     end
+
+    def key_id=(key_id)
+      push_to_secrets(key: 'key_id', value: key_id)
+    end
+
+    def private_key=(private_key)
+      push_to_secrets(key: 'private_key', value: private_key)
+    end
+
+    def key_id
+      get_from_secrets('key_id')
+    end
+
+    def private_key
+      get_from_secrets('private_key')
+    end
   end
 end

--- a/app/models/payment_providers/pinet_provider.rb
+++ b/app/models/payment_providers/pinet_provider.rb
@@ -2,9 +2,9 @@
 
 module PaymentProviders
   class PinetProvider < BaseProvider
-    validates :secret_key, presence: true
-    validates :create_customers, inclusion: { in: [true, false] }
     validates :success_redirect_url, url: true, allow_nil: true, length: { maximum: 1024 }
+    validates :key_id, presence: true
+    validates :private_key, presence: true
 
     def secret_key=(secret_key)
       push_to_secrets(key: 'secret_key', value: secret_key)
@@ -12,14 +12,6 @@ module PaymentProviders
 
     def secret_key
       get_from_secrets('secret_key')
-    end
-
-    def create_customers=(value)
-      push_to_settings(key: 'create_customers', value:)
-    end
-
-    def create_customers
-      get_from_settings('create_customers')
     end
 
     def webhook_id=(value)

--- a/app/services/invoices/payments/pinet_service.rb
+++ b/app/services/invoices/payments/pinet_service.rb
@@ -75,7 +75,10 @@ module Invoices
       delegate :organization, :customer, to: :invoice
 
       def client
-        @client ||= Pinet::Client.new(is_sync: @is_sync)
+        @client ||= Pinet::Client.new(
+          pinet_payment_provider: organization.pinet_payment_provider,
+          is_sync: @is_sync,
+        )
       end
 
       def should_process_payment?

--- a/app/services/payment_providers/pinet_service.rb
+++ b/app/services/payment_providers/pinet_service.rb
@@ -3,28 +3,13 @@
 module PaymentProviders
   class PinetService < BaseService
     def create_or_update(**args)
-      pinet_provider = PaymentProviders::PinetProvider.find_or_initialize_by(
-        organization_id: args[:organization_id],
-      )
-
-      secret_key = pinet_provider.secret_key
-
-      pinet_provider.secret_key = args[:secret_key] if args.key?(:secret_key)
-      pinet_provider.create_customers = args[:create_customers] if args.key?(:create_customers)
-      pinet_provider.success_redirect_url = args[:success_redirect_url] if args.key?(:success_redirect_url)
-      pinet_provider.save!
-
-      if secret_key != pinet_provider.secret_key
-
-        # PaymentProviders::Pinet::RegisterWebhookJob.perform_later(pinet_provider)
-
-        # NOTE: ensure existing payment_provider_customers are
-        #       attached to the provider
-        reattach_provider_customers(
-          organization_id: args[:organization_id],
-          pinet_provider:,
-        )
+      unless auth_token_valid?(args)
+        # TODO define a code for this error
+        return result.service_failure!(code: 'auth_token_error', message: 'Invalid token')
       end
+
+      pinet_provider = find_or_initialize_provider(args[:organization_id])
+      update_provider_keys(pinet_provider, args[:private_key], args[:key_id])
 
       result.pinet_provider = pinet_provider
       result
@@ -34,11 +19,33 @@ module PaymentProviders
 
     private
 
-    def reattach_provider_customers(organization_id:, pinet_provider:)
+    def auth_token_valid?(args)
+      auth_token = Pinet::JwtService.create_jwt(private_key: args[:private_key], key_id: args[:key_id])
+      Pinet::Client.new.valid_auth_token?(auth_token)
+    rescue OpenSSL::PKey::RSAError
+      false
+    end
+
+    def find_or_initialize_provider(organization_id)
+      PaymentProviders::PinetProvider.find_or_initialize_by(organization_id:)
+    end
+
+    def update_provider_keys(pinet_provider, private_key, key_id)
+      old_key_id = pinet_provider.key_id
+      old_private_key = pinet_provider.private_key
+
+      pinet_provider.update!(key_id:, private_key:)
+
+      return unless old_key_id != key_id || old_private_key != private_key
+
+      reattach_provider_customers(pinet_provider)
+    end
+
+    def reattach_provider_customers(pinet_provider)
       PaymentProviderCustomers::PinetCustomer
         .joins(:customer)
-        .where(payment_provider_id: nil, customers: { organization_id: })
-        .update_all(payment_provider_id: pinet_provider.id) # rubocop:disable Rails/SkipsModelValidations
+        .where(payment_provider_id: nil, customers: { organization_id: pinet_provider.organization_id })
+        .update_all(payment_provider_id: pinet_provider.id)
     end
   end
 end

--- a/app/services/payment_providers/pinet_service.rb
+++ b/app/services/payment_providers/pinet_service.rb
@@ -4,7 +4,7 @@ module PaymentProviders
   class PinetService < BaseService
     def create_or_update(**args)
       unless auth_token_valid?(args)
-        # TODO define a code for this error
+        # TODO: define a code for this error
         return result.service_failure!(code: 'auth_token_error', message: 'Invalid token')
       end
 

--- a/lib/pinet/client.rb
+++ b/lib/pinet/client.rb
@@ -57,7 +57,7 @@ module Pinet
       false
     end
 
-    # private
+    private
 
     attr_reader :pinet_payment_provider, :is_sync
 

--- a/lib/pinet/jwt_service.rb
+++ b/lib/pinet/jwt_service.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'jwt'
 
 module Pinet
   class JwtService
     EXPIRATION_PERIOD = 3600 # unit: seconds
 
-    def self.create_jwt
+    def self.create_jwt(private_key: nil, key_id: nil)
       iat = Time.now.utc.to_i
       exp = iat + EXPIRATION_PERIOD
 
@@ -15,8 +17,8 @@ module Pinet
         'exp' => exp,
       }
 
-      private_key = OpenSSL::PKey::RSA.new(ENV['PUBLISHER_PRIVATE_KEY_FROM_JSON'])
-      kid = ENV['PUBLISHER_PRIVATE_KEY_ID_FROM_JSON']
+      private_key = OpenSSL::PKey::RSA.new(private_key || ENV['PUBLISHER_PRIVATE_KEY_FROM_JSON'])
+      kid = key_id || ENV['PUBLISHER_PRIVATE_KEY_ID_FROM_JSON']
 
       additional_headers = { 'kid' => kid }
       JWT.encode(payload, private_key, 'RS256', additional_headers)

--- a/lib/pinet/jwt_service.rb
+++ b/lib/pinet/jwt_service.rb
@@ -17,8 +17,8 @@ module Pinet
         'exp' => exp,
       }
 
-      private_key = OpenSSL::PKey::RSA.new(private_key || ENV['PUBLISHER_PRIVATE_KEY_FROM_JSON'])
-      kid = key_id || ENV['PUBLISHER_PRIVATE_KEY_ID_FROM_JSON']
+      private_key = OpenSSL::PKey::RSA.new(private_key)
+      kid = key_id
 
       additional_headers = { 'kid' => kid }
       JWT.encode(payload, private_key, 'RS256', additional_headers)

--- a/schema.graphql
+++ b/schema.graphql
@@ -79,6 +79,8 @@ input AddPinetPaymentProviderInput {
   """
   clientMutationId: String
   createCustomers: Boolean
+  keyId: String!
+  privateKey: String!
   secretKey: String
   successRedirectUrl: String
 }
@@ -192,6 +194,7 @@ enum BillingTimeEnum {
 
 type Charge {
   billableMetric: BillableMetric!
+  chargeGroup: ChargeGroup
   chargeModel: ChargeModelEnum!
   createdAt: ISO8601DateTime!
   deletedAt: ISO8601DateTime
@@ -207,8 +210,42 @@ type Charge {
   updatedAt: ISO8601DateTime!
 }
 
+type ChargeGroup {
+  charges: [Charge!]
+  createdAt: ISO8601DateTime!
+  deletedAt: ISO8601DateTime
+  id: ID!
+  invoiceDisplayName: String
+  invoiceable: Boolean!
+  minAmountCents: BigInt!
+  payInAdvance: Boolean!
+  properties: ChargeGroupProperties!
+  updatedAt: ISO8601DateTime!
+  usageChargeGroups: [UsageChargeGroup!]
+}
+
+input ChargeGroupInput {
+  id: ID
+  invoiceDisplayName: String
+  invoiceable: Boolean
+  minAmountCents: BigInt
+  payInAdvance: Boolean
+  properties: ChargeGroupPropertiesInput
+}
+
+type ChargeGroupProperties {
+  amount: String
+  freeUnits: BigInt
+}
+
+input ChargeGroupPropertiesInput {
+  amount: String
+  freeUnits: BigInt
+}
+
 input ChargeInput {
   billableMetricId: ID!
+  chargeGroupId: ID
   chargeModel: ChargeModelEnum!
   groupProperties: [GroupPropertiesInput!]
   id: ID
@@ -225,6 +262,7 @@ enum ChargeModelEnum {
   graduated
   graduated_percentage
   package
+  package_group
   percentage
   standard
   timebased
@@ -1790,6 +1828,7 @@ input CreatePlanInput {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   billChargesMonthly: Boolean
+  chargeGroups: [ChargeGroupInput!]
   charges: [ChargeInput!]!
 
   """
@@ -4188,7 +4227,9 @@ input OrganizationBillingConfigurationInput {
 type PinetProvider {
   createCustomers: Boolean!
   id: ID!
-  secretKey: String!
+  keyId: String!
+  privateKey: String!
+  secretKey: String
   successRedirectUrl: String
 }
 
@@ -4197,6 +4238,12 @@ type Plan {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   billChargesMonthly: Boolean
+  chargeGroups: [ChargeGroup!]
+
+  """
+  Number of charge groups attached to a plan
+  """
+  chargeGroupsCount: Int!
   charges: [Charge!]
 
   """
@@ -5943,6 +5990,17 @@ input UpdateSubscriptionInput {
   name: String
   planOverrides: PlanOverridesInput
   subscriptionAt: ISO8601DateTime
+}
+
+type UsageChargeGroup {
+  availableGroupUsage: JSON
+  chargeGroup: ChargeGroup!
+  createdAt: ISO8601DateTime!
+  currentPackageCount: BigInt!
+  deletedAt: ISO8601DateTime
+  id: ID!
+  subscription: Subscription!
+  updatedAt: ISO8601DateTime!
 }
 
 type User {

--- a/schema.graphql
+++ b/schema.graphql
@@ -5938,6 +5938,7 @@ input UpdatePlanInput {
   amountCents: BigInt!
   amountCurrency: CurrencyEnum!
   billChargesMonthly: Boolean
+  chargeGroups: [ChargeGroupInput!]
   charges: [ChargeInput!]!
 
   """

--- a/schema.graphql
+++ b/schema.graphql
@@ -4225,11 +4225,9 @@ input OrganizationBillingConfigurationInput {
 }
 
 type PinetProvider {
-  createCustomers: Boolean!
   id: ID!
   keyId: String!
   privateKey: String!
-  secretKey: String
   successRedirectUrl: String
 }
 

--- a/schema.json
+++ b/schema.json
@@ -18649,24 +18649,6 @@
           "possibleTypes": null,
           "fields": [
             {
-              "name": "createCustomers",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "Boolean",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
               "name": "id",
               "description": null,
               "type": {
@@ -18713,20 +18695,6 @@
                   "name": "String",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null,
-              "args": [
-
-              ]
-            },
-            {
-              "name": "secretKey",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,

--- a/schema.json
+++ b/schema.json
@@ -26546,6 +26546,26 @@
               "deprecationReason": null
             },
             {
+              "name": "chargeGroups",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ChargeGroupInput",
+                    "ofType": null
+                  }
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "charges",
               "description": null,
               "type": {

--- a/schema.json
+++ b/schema.json
@@ -573,6 +573,38 @@
               "deprecationReason": null
             },
             {
+              "name": "keyId",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "privateKey",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {
@@ -1748,6 +1780,20 @@
               ]
             },
             {
+              "name": "chargeGroup",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "ChargeGroup",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
               "name": "chargeModel",
               "description": null,
               "type": {
@@ -1982,6 +2028,376 @@
           "enumValues": null
         },
         {
+          "kind": "OBJECT",
+          "name": "ChargeGroup",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "charges",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Charge",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "invoiceable",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "minAmountCents",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "payInAdvance",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "properties",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ChargeGroupProperties",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "usageChargeGroups",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "UsageChargeGroup",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ChargeGroupInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceDisplayName",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "invoiceable",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "minAmountCents",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "payInAdvance",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "properties",
+              "description": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "ChargeGroupPropertiesInput",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "ChargeGroupProperties",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "amount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "freeUnits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
+          "enumValues": null
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "ChargeGroupPropertiesInput",
+          "description": null,
+          "interfaces": null,
+          "possibleTypes": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "amount",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "freeUnits",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "BigInt",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "enumValues": null
+        },
+        {
           "kind": "INPUT_OBJECT",
           "name": "ChargeInput",
           "description": null,
@@ -2000,6 +2416,18 @@
                   "name": "ID",
                   "ofType": null
                 }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "chargeGroupId",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ID",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -2189,6 +2617,12 @@
             },
             {
               "name": "graduated_percentage",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "package_group",
               "description": null,
               "isDeprecated": false,
               "deprecationReason": null
@@ -6319,6 +6753,26 @@
                 "kind": "SCALAR",
                 "name": "Float",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "chargeGroups",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "ChargeGroupInput",
+                    "ofType": null
+                  }
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -18231,7 +18685,7 @@
               ]
             },
             {
-              "name": "secretKey",
+              "name": "keyId",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -18241,6 +18695,38 @@
                   "name": "String",
                   "ofType": null
                 }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "privateKey",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "secretKey",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -18336,6 +18822,46 @@
                 "kind": "SCALAR",
                 "name": "Boolean",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "chargeGroups",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ChargeGroup",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "chargeGroupsCount",
+              "description": "Number of charge groups attached to a plan",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null,
@@ -26281,6 +26807,155 @@
               "deprecationReason": null
             }
           ],
+          "enumValues": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "UsageChargeGroup",
+          "description": null,
+          "interfaces": [
+
+          ],
+          "possibleTypes": null,
+          "fields": [
+            {
+              "name": "availableGroupUsage",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "JSON",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "chargeGroup",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "ChargeGroup",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "createdAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "currentPackageCount",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "BigInt",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "deletedAt",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "ISO8601DateTime",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "id",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "subscription",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Subscription",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            },
+            {
+              "name": "updatedAt",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ISO8601DateTime",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+
+              ]
+            }
+          ],
+          "inputFields": null,
           "enumValues": null
         },
         {


### PR DESCRIPTION
## What
- Added fields key_id and private_key to the Pinet GraphQL type.
- Utilized the key_id and private_key provided from `Pinet payment provider` to authenticate with PINET.
- Refactored `create_or_update` method in PinetService to ensure the validity of `authentication tokens`.

## Why
- This update is about using `API certificate` to authentication instead of `secret key`. It's base on https://github.com/Pressingly/PINET/discussions/31

## Self test
```
key_id = <key_id>
private_key=<private_key>
auth_token = Pinet::JwtService.create_jwt(private_key: private_key, key_id: key_id)
Pinet::Client.new.valid_auth_token?(auth_token)
```
<img width="1209" alt="image" src="https://github.com/Pressingly/lagu-api/assets/45629756/1f86317a-8d3f-48b4-98cc-fea8cf3d96b8">

## TODO
- [ ] Add unit test
- [ ] Use private_key and key_id from pinet_payment_provider
