### PR TITLE
Simplify Package Time-Based Group Detection

### DIFF
--- a/app/services/timebased_events/package_timebased_group/create_service.rb
+++ b/app/services/timebased_events/package_timebased_group/create_service.rb
@@ -55,7 +55,7 @@ module TimebasedEvents
       def matching_grouped_charge_model?
         return false if matching_charge.blank?
 
-        matching_charge.charge_model == 'package_group' && charge_has_eligible_grouped_charge_model?
+        matching_charge.charge_model == 'package_group' && is_grouped_with_timebased_charge?
       end
 
       def subscription
@@ -81,10 +81,8 @@ module TimebasedEvents
         ).first
       end
 
-      def charge_has_eligible_grouped_charge_model?
-        return false if matching_charge.blank?
-
-        matching_charge.charge_group.charges.count == 2 && timebased_charge.present? && package_charge.present?
+      def is_grouped_with_timebased_charge?
+        timebased_charge.present?
       end
 
       def timebased_charge

--- a/app/services/utils/charge_group_type_determiner_service.rb
+++ b/app/services/utils/charge_group_type_determiner_service.rb
@@ -16,37 +16,18 @@ module Utils
     attr_reader :charge_group
 
     def charge_group_type
-      return Constants::CHARGE_GROUP_TYPES[:PACKAGES_GROUP] if is_packages_group?
-      return Constants::CHARGE_GROUP_TYPES[:PACKAGE_TIMEBASED_GROUP] if is_package_timebased_group?
+      return Constants::CHARGE_GROUP_TYPES[:PACKAGES_GROUP] if all_charges_are_package_group?
+      return Constants::CHARGE_GROUP_TYPES[:PACKAGE_TIMEBASED_GROUP] if has_one_timebased_charge?
 
       Constants::CHARGE_GROUP_TYPES[:UNKNOWN]
     end
 
-    def is_package_timebased_group?
-      has_exactly_two_charges? &&
-        one_timebased_charge? &&
-        one_package_group_charge?
-    end
-
-    def is_packages_group?
-      has_exactly_two_charges? &&
-        all_charges_are_package_group?
-    end
-
-    def has_exactly_two_charges?
-      charge_group.charges.count == 2
-    end
-
-    def one_timebased_charge?
+    def has_one_timebased_charge?
       charge_group.charges.timebased.count == 1
     end
 
-    def one_package_group_charge?
-      charge_group.charges.package_group.count == 1
-    end
-
     def all_charges_are_package_group?
-      charge_group.charges.package_group.count == 2
+      charge_group.charges.count == charge_group.charges.package_group.count
     end
   end
 end

--- a/app/services/utils/charge_group_type_determiner_service.rb
+++ b/app/services/utils/charge_group_type_determiner_service.rb
@@ -17,7 +17,9 @@ module Utils
 
     def charge_group_type
       return Constants::CHARGE_GROUP_TYPES[:PACKAGES_GROUP] if all_charges_are_package_group?
-      return Constants::CHARGE_GROUP_TYPES[:PACKAGE_TIMEBASED_GROUP] if has_one_timebased_charge?
+      if has_one_timebased_charge? && has_at_least_one_package_group?
+        return Constants::CHARGE_GROUP_TYPES[:PACKAGE_TIMEBASED_GROUP]
+      end
 
       Constants::CHARGE_GROUP_TYPES[:UNKNOWN]
     end
@@ -28,6 +30,10 @@ module Utils
 
     def all_charges_are_package_group?
       charge_group.charges.count == charge_group.charges.package_group.count
+    end
+
+    def has_at_least_one_package_group?
+      charge_group.charges.package_group.any?
     end
   end
 end


### PR DESCRIPTION
## What
- Change `Charge Group Type` determination logic
   + `packages_group`: all charges within the group are package_group charge.
   + `package_timebased_group`: A charge group contains one timebased charge.
   
## Why
- To fix #51 

## Self test
- Subscribe to a plan has 3 billable metrics
<img width="1420" alt="image" src="https://github.com/Pressingly/lagu-api/assets/45629756/32f84c24-bea2-4c7e-9ce9-829569ca9969">

- Create an invoice when push event:
<img width="1410" alt="image" src="https://github.com/Pressingly/lagu-api/assets/45629756/2b85b66f-ed31-40bf-824c-388fc55ea5c6">

