### PR TITLE
fix(package time-based group): Fix available usage group  when a group charge has more than 2 billable metrics

### DIFF
--- a/app/services/timebased_events/package_timebased_group/create_service.rb
+++ b/app/services/timebased_events/package_timebased_group/create_service.rb
@@ -17,7 +17,7 @@ module TimebasedEvents
 
         if (current_package_count = event.current_package_count) > 1
           increase_current_package_count(current_package_count)
-          reset_usage_charge_group(current_package_count)
+          update_usage_charge_group(current_package_count)
         end
 
         result.timebased_event = timebased_event
@@ -90,10 +90,6 @@ module TimebasedEvents
         @timebased_charge ||= matching_charge.charge_group.charges.find_by(charge_model: 'timebased')
       end
 
-      def package_charge
-        @package_charge ||= matching_charge.charge_group.charges.find_by(charge_model: 'package_group')
-      end
-
       def process_renewal
         if sync
           renewal_result = Invoices::CreatePayInAdvanceSyncChargeJob
@@ -112,7 +108,7 @@ module TimebasedEvents
         event.update!(current_package_count: new_package_count)
       end
 
-      def reset_usage_charge_group(current_package_count)
+      def update_usage_charge_group(current_package_count)
         usage_charge_group = UsageChargeGroup.find_by(
           charge_group_id: matching_charge.charge_group.id,
           subscription_id: subscription.id,
@@ -120,16 +116,25 @@ module TimebasedEvents
 
         return unless usage_charge_group
 
-        available_group_usage = {}
-        available_group_usage[package_charge.billable_metric_id] = package_charge.properties['package_size']
+        available_group_usage = initialize_available_group_usage(usage_charge_group)
 
         usage_charge_group.update!(
           available_group_usage:,
           current_package_count: current_package_count + 1,
         )
       end
+
       def matching_billable_metric
         @matching_billable_metric ||= organization.billable_metrics.find_by(code: event.code)
+      end
+
+      def initialize_available_group_usage
+        available_group_usage = {}
+        matching_charge.charge_group.charges.package_group.each do |child_charge|
+          available_group_usage[child_charge.billable_metric_id] = child_charge.properties['package_size']
+        end
+
+        available_group_usage
       end
     end
   end

--- a/app/services/timebased_events/package_timebased_group/create_service.rb
+++ b/app/services/timebased_events/package_timebased_group/create_service.rb
@@ -116,7 +116,7 @@ module TimebasedEvents
 
         return unless usage_charge_group
 
-        available_group_usage = initialize_available_group_usage(usage_charge_group)
+        available_group_usage = initialize_available_group_usage
 
         usage_charge_group.update!(
           available_group_usage:,

--- a/app/services/timebased_events/package_timebased_group/create_service.rb
+++ b/app/services/timebased_events/package_timebased_group/create_service.rb
@@ -77,6 +77,7 @@ module TimebasedEvents
 
         @matching_charge ||= Charge.where(
           charge_model: :package_group,
+          billable_metric_id: matching_billable_metric.id,
           plan_id: plan.id,
         ).first
       end
@@ -126,6 +127,9 @@ module TimebasedEvents
           available_group_usage:,
           current_package_count: current_package_count + 1,
         )
+      end
+      def matching_billable_metric
+        @matching_billable_metric ||= organization.billable_metrics.find_by(code: event.code)
       end
     end
   end


### PR DESCRIPTION
## What
- Fix available_group_usage calculations for usage charge groups, regardless of the number of packages within the charge group.

## How to test
- Add a plan `4 articles & 5 GB & 5 minutes` to customer
<img width="1232" alt="image" src="https://github.com/Pressingly/lagu-api/assets/45629756/637cf8e4-76fe-46ed-9c97-4a368dd2740c">
- Send `5 articles` consecutively, invoice will be generated for the `1st` and `5th` times
<img width="1233" alt="Screenshot 2024-03-20 at 08 46 57" src="https://github.com/Pressingly/lagu-api/assets/45629756/92792e1f-707b-4590-922e-d942128e7dbe">
- Send an event for the 'GB' billable metric; this will generate a $0 invoice.
<img width="1201" alt="image" src="https://github.com/Pressingly/lagu-api/assets/45629756/ae912841-da2a-429a-a057-b4fd909a2222">

